### PR TITLE
Improve Raw Filtering

### DIFF
--- a/lib/paginator.js
+++ b/lib/paginator.js
@@ -89,7 +89,13 @@ Paginator.prototype.prepateQuery = function() {
 
   _.keys(this.where).forEach(
     function(key) {
-      fixedWhere[this.realTableNames[key] ? this.realTableNames[key] : key] = this.where[key];
+
+      // raw filters should not have table name as prefix
+      if (this.options.rawFilters && this.options.rawFilters[key]) {
+        fixedWhere[key] = this.where[key];
+      } else {
+        fixedWhere[this.realTableNames[key] ? this.realTableNames[key] : key] = this.where[key];
+      }
     }.bind(this)
   );
 
@@ -103,10 +109,18 @@ Paginator.prototype.prepateQuery = function() {
 
   this.whereComp = function(qb) {
     _.forIn(fixedWhere, function(value, key) {
-      debugWhere('adding where (', key, _this.comps[key], value, ')');
-      if (_this.rawFilters && _this.rawFilters[key]) {
-        qb.andWhereRaw(_this.rawFilters[key], _this.comps[key], value);
+
+      // There are two kinds of where, default and raw where
+      // raw wheres are getted from the options configuration using the current key
+      // default wheres are using directly the current key
+
+      if (_this.options.rawFilters && _this.options.rawFilters[key]) {
+
+        debugWhere('adding where (', _this.options.rawFilters[key], _this.comps[key], value, ')');
+        qb.andWhereRaw(_this.options.rawFilters[key] + ' ' + _this.comps[key] + ' \'' + value + '\'');
       } else {
+        debugWhere('adding where (', key, _this.comps[key], value, ')');
+
         qb.andWhere(key, _this.comps[key], value);
       }
     });
@@ -193,8 +207,12 @@ Paginator.prototype.buildJoins = function() {
       });
     }
 
-    if (!this.comps[_this.realTableNames[item]]) {
+    // Cache the current comparator indexed by table name
+    // in case of raw filters we index the comparator only by raw filter name
+    if (!this.comps[_this.realTableNames[item]] && !this.isRawFilter(item)) {
       this.comps[_this.realTableNames[item]] = _.isObject(this.options.comp) ? '=' : this.options.comp;
+    } else if (this.isRawFilter(item)) {
+      this.comps[item] = _.isObject(this.options.comp) ? '=' : this.options.comp
     }
 
   }.bind(this));
@@ -336,6 +354,15 @@ Paginator.prototype.getOffset = function() {
  */
 Paginator.prototype.getLimit = function() {
   return parseInt(this.options.limit);
+};
+
+/**
+ * Returns true if the filter is of type raw
+ * @param name
+ * @returns {Boolean}
+ */
+Paginator.prototype.isRawFilter = function(name) {
+  return this.options.rawFilters && this.options.rawFilters[name];
 };
 
 exports['default'] = Paginator;


### PR DESCRIPTION
Fix some bugs:
- You were using this.rawFilters instead of this.options.rawFilters
- We don't want to prefix raw filters with the table name
- andWhereRaw should only receive two parameters (sql and binding),
