### PR TITLE
Fix Bug: Raw filtering was not working with comps being an object

### DIFF
--- a/lib/paginator.js
+++ b/lib/paginator.js
@@ -77,7 +77,7 @@ Paginator.prototype.init = function(options) {
  * Build the count and data queries
  * @private
  */
-Paginator.prototype.prepateQuery = function() {
+Paginator.prototype.prepareQuery = function() {
   var fixedWhere = {};
   var baseQuery;
   var selectQuery;
@@ -178,6 +178,8 @@ Paginator.prototype.buildJoins = function() {
   var _this = this;
 
   this.options.filterBy.forEach(function(item) {
+    var filter;
+
     if (item.indexOf('.') !== -1) {
       debugJoin('building (', item, ')');
       joinCandidates = item.split('.');
@@ -199,20 +201,18 @@ Paginator.prototype.buildJoins = function() {
       this.realTableNames[item] = [this.modelInstance.tableName, item].join('.')
     }
 
+    filter = _this.isRawFilter(item) ? item : _this.realTableNames[item];
+
     if (_.isObject(this.options.comp)) {
       _.forIn(this.options.comp, function(value, key) {
         if (_.include(value, item)) {
-          _this.comps[_this.realTableNames[item]] = key;
+          _this.comps[filter] = key;
         }
       });
     }
 
-    // Cache the current comparator indexed by table name
-    // in case of raw filters we index the comparator only by raw filter name
-    if (!this.comps[_this.realTableNames[item]] && !this.isRawFilter(item)) {
-      this.comps[_this.realTableNames[item]] = _.isObject(this.options.comp) ? '=' : this.options.comp;
-    } else if (this.isRawFilter(item)) {
-      this.comps[item] = _.isObject(this.options.comp) ? '=' : this.options.comp
+    if (!this.comps[filter]) {
+      this.comps[filter] = _.isObject(this.options.comp) ? '=' : this.options.comp;
     }
 
   }.bind(this));
@@ -290,11 +290,10 @@ Paginator.prototype.buildJoin = function(relation) {
  * @param options
  */
 Paginator.prototype.paginate = function(filter, options) {
-  var ids;
   this.where = _.pick(filter, this.options.filterBy);
 
   this.init(filter);
-  this.prepateQuery();
+  this.prepareQuery();
 
   return Promise.props({
     total: this.countQuery,

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -38,12 +38,13 @@ var configs = {
   }
 };
 
-function insert(cant, gender) {
+function insert(cant, gender, profile) {
   return Promise.map(new Array(cant).join(0).split(0).map(Number.call, Number), function() {
     return datastore.knex('person').insert({
       firstname: chance.first(),
       lastname: chance.last(),
-      gender: gender
+      gender: gender,
+      profile: profile
     });
   });
 }
@@ -65,9 +66,9 @@ function recreateDatabase(type) {
 
     case 'postgres':
       conn = config.connection;
-      return exec('echo "DROP DATABASE IF EXISTS ' + conn.database + '" | psql -U ' + conn.user)
+      return exec('echo "DROP DATABASE IF EXISTS ' + conn.database + '" | psql -U ' + conn.user + ' -h ' + conn.host)
         .then(function() {
-          return exec('psql -c\'create database ' + conn.database + '\' -U ' + conn.user);
+          return exec('psql -c\'create database ' + conn.database + '\' -U ' + conn.user + ' -h ' + conn.host);
         });
 
     case 'mysql':
@@ -127,6 +128,7 @@ function initilize(type) {
             table.string('firstname');
             table.string('lastname');
             table.string('gender');
+            table.json('profile');
           }
 
         ),
@@ -151,7 +153,7 @@ function initilize(type) {
       );
     })
     .then(function() {
-      return Promise.all([insert(50, 'female'), insert(30, 'male')]);
+      return Promise.all([insert(50, 'female', {address: 'Venus'}), insert(30, 'male', {address: 'Mars'})]);
     })
     .then(function() {
       var languages = [

--- a/test/paginator.spec.js
+++ b/test/paginator.spec.js
@@ -362,5 +362,35 @@ describe('Paginator', function() {
           done(err);
         });
     });
+
+    if (process.env.DB_TYPE === 'postgres') {
+      it('able to paginate using raw filter', function(done) {
+        var paginator = new Paginator('Person', {
+          filterBy: ['lastname', 'address'],
+          rawFilters: {
+            address: 'person.profile ->> \'address\''
+          },
+          comp: {
+            ILIKE: ['lastname', 'address']
+          }
+        });
+
+        paginator
+          .paginate({address: 'venus', limit: 100})
+          .then(function() {
+            var people = paginator.getData();
+            should(people.length).equal(50, 'We should have 50 people from venus');
+
+            paginator.getData().map(function(person) {
+              should(person.get('profile').address).match(/^Venus/);
+            });
+
+            done();
+          })
+          .catch(function(err) {
+            done(err);
+          });
+      });
+    }
   });
 });


### PR DESCRIPTION
This code was not working, the paginator was using the operator "=" (by default) to compare rawFIlters

``` javascript
var paginator = new Paginator('Person', {
          filterBy: ['lastname', 'address'],
          rawFilters: {
            address: 'person.profile ->> \'address\''
          },
          comp: {
            ILIKE: ['lastname', 'address']
          }
        });

        paginator
          .paginate({address: 'venus', limit: 100})
```
